### PR TITLE
Add theme toggle

### DIFF
--- a/dry-martini-web/src/App.js
+++ b/dry-martini-web/src/App.js
@@ -8,7 +8,7 @@ import SummaryPanel from './components/SummaryPanel';
 import DocumentsPanel from './components/DocumentsPanel';
 import PdfViewer from './components/PdfViewer';
 import FundHoldingsPanel from './components/FundHoldingsPanel';
-import { darkTheme } from './theme';
+import { darkTheme, lightTheme } from './theme';
 
 export default function App() {
   const [list, setList] = useState([]);
@@ -22,6 +22,7 @@ export default function App() {
   const [skip, setSkip] = useState(0);
   const [hasMore, setHasMore] = useState(true);
   const [sortMethod, setSortMethod] = useState('popularity');
+  const [themeMode, setThemeMode] = useState('dark');
 
   const securityCache = useRef({});
   const limit = 100;
@@ -114,15 +115,21 @@ export default function App() {
     }
   };
 
+  const toggleTheme = () => {
+    setThemeMode(prev => (prev === 'dark' ? 'light' : 'dark'));
+  };
+
   const filtered = list.filter(
     s =>
       s.isin.includes(search.toUpperCase()) ||
       s.name.toLowerCase().includes(search.toLowerCase())
   );
 
+  const theme = themeMode === 'dark' ? darkTheme : lightTheme;
+
   return (
-    <ThemeProvider theme={darkTheme}>
-      <TopBar />
+    <ThemeProvider theme={theme}>
+      <TopBar themeMode={themeMode} toggleTheme={toggleTheme} />
 
       <Box sx={{ display: 'flex', height: 'calc(100vh - 48px)', bgcolor: 'background.default' }}>
         <Sidebar

--- a/dry-martini-web/src/components/TopBar.js
+++ b/dry-martini-web/src/components/TopBar.js
@@ -4,13 +4,23 @@ import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import Box from '@mui/material/Box';
 import Link from '@mui/material/Link';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import Brightness4Icon from '@mui/icons-material/Brightness4';
+import Brightness7Icon from '@mui/icons-material/Brightness7';
 
-export default function TopBar() {
+export default function TopBar({ themeMode, toggleTheme }) {
   return (
     <AppBar position="static" color="primary">
       <Toolbar variant="dense">
-        {/* Spacer to push "About" to the right */}
+        {/* Spacer to push controls to the right */}
         <Box sx={{ flexGrow: 1 }} />
+
+        <Tooltip title="Toggle light/dark theme">
+          <IconButton onClick={toggleTheme} color="inherit" sx={{ mr: 1 }}>
+            {themeMode === 'dark' ? <Brightness7Icon /> : <Brightness4Icon />}
+          </IconButton>
+        </Tooltip>
 
         <Link
           href="https://about.databookman.com"

--- a/dry-martini-web/src/theme.js
+++ b/dry-martini-web/src/theme.js
@@ -1,6 +1,15 @@
 // src/theme.js
 import { createTheme } from '@mui/material/styles';
 
+export const lightTheme = createTheme({
+  palette: {
+    mode: 'light',
+    background: { default: '#fafafa', paper: '#fff' },
+    primary: { main: '#1976d2' },
+    text: { primary: '#000', secondary: '#333' },
+  },
+});
+
 export const darkTheme = createTheme({
   palette: {
     mode: 'dark',


### PR DESCRIPTION
## Summary
- support light and dark themes
- allow switching theme from the header

## Testing
- `black .` *(succeeds)*
- `flake8` *(fails: command not found)*
- `pytest`
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68413ddc38448322a03ed3f3566e02f3