### PR TITLE
Add theme toggle component

### DIFF
--- a/dry-martini-web/src/App.js
+++ b/dry-martini-web/src/App.js
@@ -8,7 +8,7 @@ import SummaryPanel from './components/SummaryPanel';
 import DocumentsPanel from './components/DocumentsPanel';
 import PdfViewer from './components/PdfViewer';
 import FundHoldingsPanel from './components/FundHoldingsPanel';
-import { darkTheme } from './theme';
+import { darkTheme, lightTheme } from './theme';
 
 export default function App() {
   const [list, setList] = useState([]);
@@ -22,6 +22,9 @@ export default function App() {
   const [skip, setSkip] = useState(0);
   const [hasMore, setHasMore] = useState(true);
   const [sortMethod, setSortMethod] = useState('popularity');
+  const [mode, setMode] = useState('dark');
+
+  const theme = mode === 'dark' ? darkTheme : lightTheme;
 
   const securityCache = useRef({});
   const limit = 100;
@@ -120,9 +123,12 @@ export default function App() {
       s.name.toLowerCase().includes(search.toLowerCase())
   );
 
+  const toggleMode = () =>
+    setMode(prev => (prev === 'dark' ? 'light' : 'dark'));
+
   return (
-    <ThemeProvider theme={darkTheme}>
-      <TopBar />
+    <ThemeProvider theme={theme}>
+      <TopBar mode={mode} toggleMode={toggleMode} />
 
       <Box sx={{ display: 'flex', height: 'calc(100vh - 48px)', bgcolor: 'background.default' }}>
         <Sidebar

--- a/dry-martini-web/src/components/ThemeToggle.js
+++ b/dry-martini-web/src/components/ThemeToggle.js
@@ -1,0 +1,42 @@
+// src/components/ThemeToggle.js
+import React from 'react';
+import Box from '@mui/material/Box';
+import Switch from '@mui/material/Switch';
+import LightModeIcon from '@mui/icons-material/LightMode';
+import DarkModeIcon from '@mui/icons-material/DarkMode';
+
+export default function ThemeToggle({ mode, toggleMode }) {
+  return (
+    <Box sx={{ position: 'relative', ml: 2, mr: 1 }}>
+      <LightModeIcon
+        sx={{
+          position: 'absolute',
+          top: '50%',
+          left: 4,
+          transform: 'translateY(-50%)',
+          fontSize: 16,
+        }}
+      />
+      <DarkModeIcon
+        sx={{
+          position: 'absolute',
+          top: '50%',
+          right: 4,
+          transform: 'translateY(-50%)',
+          fontSize: 16,
+        }}
+      />
+      <Switch
+        checked={mode === 'dark'}
+        onChange={toggleMode}
+        size="small"
+        sx={{
+          width: 40,
+          '& .MuiSwitch-switchBase': { p: 0, m: 0 },
+          '& .MuiSwitch-thumb': { width: 16, height: 16 },
+          '& .MuiSwitch-track': { opacity: 1, px: 3 },
+        }}
+      />
+    </Box>
+  );
+}

--- a/dry-martini-web/src/components/TopBar.js
+++ b/dry-martini-web/src/components/TopBar.js
@@ -4,8 +4,9 @@ import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import Box from '@mui/material/Box';
 import Link from '@mui/material/Link';
+import ThemeToggle from './ThemeToggle';
 
-export default function TopBar() {
+export default function TopBar({ mode, toggleMode }) {
   return (
     <AppBar position="static" color="primary">
       <Toolbar variant="dense">
@@ -22,6 +23,8 @@ export default function TopBar() {
         >
           About
         </Link>
+
+        <ThemeToggle mode={mode} toggleMode={toggleMode} />
       </Toolbar>
     </AppBar>
   );

--- a/dry-martini-web/src/theme.js
+++ b/dry-martini-web/src/theme.js
@@ -1,6 +1,15 @@
 // src/theme.js
 import { createTheme } from '@mui/material/styles';
 
+export const lightTheme = createTheme({
+  palette: {
+    mode: 'light',
+    background: { default: '#fafafa', paper: '#fff' },
+    primary: { main: '#1976d2' },
+    text: { primary: '#000', secondary: '#333' },
+  },
+});
+
 export const darkTheme = createTheme({
   palette: {
     mode: 'dark',


### PR DESCRIPTION
## Summary
- refactor switch into a reusable `ThemeToggle` component
- use `ThemeToggle` inside `TopBar`

## Testing
- `black --check .` *(fails: 19 files would be reformatted)*
- `flake8` *(fails: command not found)*
- `pytest`
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841413c98448322bdb85ef47c2ce372