### PR TITLE
Add theme switch component to top bar

### DIFF
--- a/dry-martini-web/src/components/ThemeToggle.js
+++ b/dry-martini-web/src/components/ThemeToggle.js
@@ -1,0 +1,39 @@
+// src/components/ThemeToggle.js
+import React from 'react';
+import { styled } from '@mui/material/styles';
+import Box from '@mui/material/Box';
+import Switch from '@mui/material/Switch';
+import Brightness4Icon from '@mui/icons-material/Brightness4';
+import Brightness7Icon from '@mui/icons-material/Brightness7';
+
+const ToggleContainer = styled(Box)({
+  position: 'relative',
+  display: 'inline-flex',
+  alignItems: 'center',
+});
+
+const IconWrapper = styled(Box)({
+  position: 'absolute',
+  top: '50%',
+  transform: 'translateY(-50%)',
+  pointerEvents: 'none',
+});
+
+export default function ThemeToggle({ themeMode, toggleTheme }) {
+  return (
+    <ToggleContainer sx={{ width: 48 }}>
+      <IconWrapper sx={{ left: 4 }}>
+        <Brightness7Icon fontSize="small" />
+      </IconWrapper>
+      <Switch
+        checked={themeMode === 'dark'}
+        onChange={toggleTheme}
+        color="default"
+        size="small"
+      />
+      <IconWrapper sx={{ right: 4 }}>
+        <Brightness4Icon fontSize="small" />
+      </IconWrapper>
+    </ToggleContainer>
+  );
+}

--- a/dry-martini-web/src/components/TopBar.js
+++ b/dry-martini-web/src/components/TopBar.js
@@ -4,10 +4,8 @@ import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import Box from '@mui/material/Box';
 import Link from '@mui/material/Link';
-import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
-import Brightness4Icon from '@mui/icons-material/Brightness4';
-import Brightness7Icon from '@mui/icons-material/Brightness7';
+import ThemeToggle from './ThemeToggle';
 
 export default function TopBar({ themeMode, toggleTheme }) {
   return (
@@ -15,12 +13,6 @@ export default function TopBar({ themeMode, toggleTheme }) {
       <Toolbar variant="dense">
         {/* Spacer to push controls to the right */}
         <Box sx={{ flexGrow: 1 }} />
-
-        <Tooltip title="Toggle light/dark theme">
-          <IconButton onClick={toggleTheme} color="inherit" sx={{ mr: 1 }}>
-            {themeMode === 'dark' ? <Brightness7Icon /> : <Brightness4Icon />}
-          </IconButton>
-        </Tooltip>
 
         <Link
           href="https://about.databookman.com"
@@ -32,6 +24,12 @@ export default function TopBar({ themeMode, toggleTheme }) {
         >
           About
         </Link>
+
+        <Tooltip title="Toggle light/dark theme">
+          <Box sx={{ ml: 1 }}>
+            <ThemeToggle themeMode={themeMode} toggleTheme={toggleTheme} />
+          </Box>
+        </Tooltip>
       </Toolbar>
     </AppBar>
   );


### PR DESCRIPTION
## Summary
- add `ThemeToggle` component containing a switch with icons
- update `TopBar` to use `ThemeToggle` and move the toggle to the right of the About link

## Testing
- `black .`
- `flake8` *(fails: command not found)*
- `pytest`
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68414481717483228150bf4a45551990