### PR TITLE
docs: clarify scope restrictions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,12 @@
 This repository contains a Python FastAPI backend and a React frontend.
 The following rules apply to any changes made in this repository:
 
+## Scope Restrictions
+- When a request involves fixing frontend design or bugs, only modify the React
+  frontend and do not touch backend code.
+- When a request involves backend functionality or bug fixes, keep frontend files
+  unchanged.
+
 ## Required Checks
 - Format Python code with `black .`.
 - Lint Python code using `flake8`.


### PR DESCRIPTION
## Summary
- note separation between frontend and backend in `AGENTS.md`

## Testing
- `black .` *(reformatted files then reverted)*
- `flake8` *(failed: command not found)*
- `pytest`
- `npm test` *(failed: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841510bf4c0832294abdca4a31afb0d