### PR TITLE
Fix theme toggle layout

### DIFF
--- a/dry-martini-web/src/components/ThemeToggle.js
+++ b/dry-martini-web/src/components/ThemeToggle.js
@@ -13,17 +13,18 @@ export default function ThemeToggle({ themeMode, toggleTheme }) {
 
   return (
     <Box sx={{ display: 'flex', alignItems: 'center' }}>
-      {isDark ? (
-        <Brightness4Icon fontSize="small" sx={{ mr: 0.5 }} />
-      ) : (
-        <Brightness7Icon fontSize="small" sx={{ mr: 0.5 }} />
-      )}
       <Switch
         checked={isDark}
         onChange={toggleTheme}
         color="default"
         size="small"
+        sx={{ mr: 0.5 }}
       />
+      {isDark ? (
+        <Brightness4Icon fontSize="small" />
+      ) : (
+        <Brightness7Icon fontSize="small" />
+      )}
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- adjust ThemeToggle layout so the switch appears left of the icon

## Testing
- `black .`
- `flake8` *(fails: command not found)*
- `pytest`
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684151c540b48322a16dc857b5fb2c42